### PR TITLE
fix: non initialized variable

### DIFF
--- a/src/calib/HandEyeCalibration.cc
+++ b/src/calib/HandEyeCalibration.cc
@@ -75,7 +75,7 @@ static Eigen::MatrixXd ScrewToStransposeBlockofT(
                                                     )
 {
         Eigen::MatrixXd Stranspose(6,8);
-
+        Stranspose.setZero();
 
         typedef Eigen::Matrix<T, 3, 1> VecT;
         auto skew_a_plus_b = skew(VecT(a + b));


### PR DESCRIPTION
This non initialized matrix lead to a lot of `nan` in the matrix used after and failed to build the `Eigen::JacobiSVD<Eigen::MatrixXd> svd` later.